### PR TITLE
add app back button

### DIFF
--- a/app/src/main/java/com/paris_2/san3a/presentation/shared/components/AppBackButton.kt
+++ b/app/src/main/java/com/paris_2/san3a/presentation/shared/components/AppBackButton.kt
@@ -1,12 +1,10 @@
 package com.paris_2.san3a.presentation.shared.components
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -23,20 +21,17 @@ import com.paris_2.san3a.presentation.shared.designSystem.theme.Theme
 fun AppBackButton(
     onClickBackButton: () -> Unit,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
     painter: Painter = painterResource(id = R.drawable.ic_arrow_left_outline),
     iconContentDescription: String? = null
 ) {
-    Button(
+    IconButton(
         modifier = modifier
             .size(48.dp)
-            .background(
-                color = Theme.colors.background.card,
-                shape = RoundedCornerShape(Theme.radius.full)
-            )
             .clip(RoundedCornerShape(Theme.radius.full)),
         onClick = { onClickBackButton() },
-        colors = ButtonDefaults.buttonColors(containerColor = Theme.colors.background.card),
-        contentPadding = PaddingValues(12.dp)
+        enabled = enabled,
+        colors = IconButtonDefaults.iconButtonColors(containerColor = Theme.colors.background.card),
     ) {
         Icon(
             modifier = Modifier.size(24.dp),

--- a/app/src/main/java/com/paris_2/san3a/presentation/shared/components/AppBackButton.kt
+++ b/app/src/main/java/com/paris_2/san3a/presentation/shared/components/AppBackButton.kt
@@ -1,0 +1,59 @@
+package com.paris_2.san3a.presentation.shared.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.paris_2.san3a.R
+import com.paris_2.san3a.presentation.shared.designSystem.theme.San3aTheme
+import com.paris_2.san3a.presentation.shared.designSystem.theme.Theme
+
+@Composable
+fun AppBackButton(
+    onClickBackButton: () -> Unit,
+    modifier: Modifier = Modifier,
+    painter: Painter = painterResource(id = R.drawable.ic_arrow_left_outline),
+    iconContentDescription: String? = null
+) {
+    Button(
+        modifier = modifier
+            .size(48.dp)
+            .background(
+                color = Theme.colors.background.card,
+                shape = RoundedCornerShape(Theme.radius.full)
+            )
+            .clip(RoundedCornerShape(Theme.radius.full)),
+        onClick = { onClickBackButton() },
+        colors = ButtonDefaults.buttonColors(containerColor = Theme.colors.background.card),
+        contentPadding = PaddingValues(12.dp)
+    ) {
+        Icon(
+            modifier = Modifier.size(24.dp),
+            painter = painter,
+            contentDescription = iconContentDescription,
+            tint = Theme.colors.shade.primary
+        )
+    }
+}
+
+@Preview
+@PreviewLightDark
+@Composable
+private fun AppBackButtonPreview() {
+    San3aTheme {
+        AppBackButton(
+            onClickBackButton = {}
+        )
+    }
+}


### PR DESCRIPTION
<img width="250" height="176" alt="image" src="https://github.com/user-attachments/assets/479c9974-008a-47cc-86f4-1feacc7703b6" />
This pull request introduces a new reusable `AppBackButton` component in the `shared.components` package. The component provides a customizable back button with theming support and preview annotations for design consistency.

### New shared UI component:
* **`AppBackButton`**: A composable function that creates a back button with customizable click behavior, icon, and content description. It uses theming properties for consistent styling, including background color, shape, and icon tint. (`app/src/main/java/com/paris_2/san3a/presentation/shared/components/AppBackButton.kt`)

### Preview support:
* Added `@Preview` and `@PreviewLightDark` annotations to provide light and dark mode previews of the `AppBackButton` component. (`app/src/main/java/com/paris_2/san3a/presentation/shared/components/AppBackButton.kt`)