### PR TITLE
reformat date in chat

### DIFF
--- a/app/src/main/java/com/paris_2/san3a/presentation/screen/messages/MessagesState.kt
+++ b/app/src/main/java/com/paris_2/san3a/presentation/screen/messages/MessagesState.kt
@@ -1,7 +1,10 @@
 package com.paris_2.san3a.presentation.screen.messages
 
+import android.util.Log
 import com.paris_2.san3a.domain.entity.Chat
 import com.paris_2.san3a.domain.entity.MessageContent
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.number
 
 data class MessagesState(
     val chatsMap: Map<String, ChatUI> = emptyMap(),
@@ -24,20 +27,36 @@ data class ChatUI(
 fun MessageContent.toMessageContentUI(): String {
     return when (this) {
         is MessageContent.Text -> this.content
-        is MessageContent.Image -> "\uD83D\uDDBC️" 
-        is MessageContent.Audio -> "\uD83C\uDFB5" 
+        is MessageContent.Image -> "\uD83D\uDDBC️"
+        is MessageContent.Audio -> "\uD83C\uDFB5"
     }
 }
 
 fun Chat.toChatUI(userId: String): ChatUI {
+    Log.d("ChatUI", "toChatUI: ${this.lastMessage?.time}")
     return ChatUI(
         chatId = this.id,
         lastMessage = this.lastMessage?.messageContent?.toMessageContentUI() ?: "",
-        lastMessageTime = this.lastMessage?.time?.toString() ?: "",
+        lastMessageTime = formatLastMessageTime(this.lastMessage?.time),
         lastMessageReceiverId = this.lastMessage?.receiverId ?: "",
         unreadMessagesCount = this.unreadMessagesCount,
         theOtherUserId = this.usersParticipantIds.firstOrNull { it != userId } ?: userId,
     )
+}
+
+private fun formatLastMessageTime(time: LocalDateTime?): String {
+    return time?.let {
+        try {
+            val outputFormat = java.time.format.DateTimeFormatter.ofPattern("hh:mm a")
+            val javaLocalDateTime = java.time.LocalDateTime.of(
+                it.year, it.month.number, it.day,
+                it.hour, it.minute, it.second, it.nanosecond
+            )
+            javaLocalDateTime.format(outputFormat)
+        } catch (e: Exception) {
+            ""
+        }
+    }.toString()
 }
 
 fun List<Chat>.toChatUIMap(userId: String): Map<String, ChatUI> {

--- a/app/src/main/java/com/paris_2/san3a/presentation/screen/messagesDetails/MessageDetailsUiState.kt
+++ b/app/src/main/java/com/paris_2/san3a/presentation/screen/messagesDetails/MessageDetailsUiState.kt
@@ -29,10 +29,22 @@ fun Message.toMessageUi(imageUserUrl: String, currentUserId: String) = MessageUi
     text = handleTextMessage(messageContent),
     images = handleImagesMessage(messageContent),
     anotherUserImage = imageUserUrl,
-    time = this.time.time.toString(),
+    time = formatChatTime(this.time.time),
     isReceived = this.receiverId == currentUserId,
     isSeen = this.seen,
 )
+
+private fun formatChatTime(time: kotlinx.datetime.LocalTime?): String {
+    return time?.let {
+        try {
+            val outputFormat = java.time.format.DateTimeFormatter.ofPattern("hh:mm a")
+            val javaLocalTime = java.time.LocalTime.of(it.hour, it.minute, it.second, it.nanosecond)
+            javaLocalTime.format(outputFormat)
+        } catch (e: Exception) {
+            ""
+        }
+    } ?: ""
+}
 
 fun handleTextMessage(messageContent: MessageContent): String {
     return if (messageContent is MessageContent.Text)


### PR DESCRIPTION
This pull request improves how message times are displayed in the chat UI by introducing proper time formatting for both chat previews and individual messages. Instead of displaying raw time objects, formatted strings are shown to users, enhancing readability. The changes also add error handling to prevent crashes from invalid date/time values.

**Time formatting improvements:**

* Added the `formatLastMessageTime` function to format `LocalDateTime` objects in chat previews using the pattern `"hh:mm a"`, and updated `Chat.toChatUI` to use this formatted time instead of the raw value.
* Added the `formatChatTime` function to format `LocalTime` objects in message details using the same pattern, and updated `Message.toMessageUi` to use this formatted time.

**Code safety and logging:**

* Wrapped time formatting in try-catch blocks to handle potential exceptions and avoid crashes due to malformed date/time values. [[1]](diffhunk://#diff-95c9be68086f367ffcfcc275d411e744b991ce81ba6c505eaefe54389440a454R36-R61) [[2]](diffhunk://#diff-e284efd9df642d59b056ba682fc0516e5f49eeb566f46c3dce5bcdc41d1f991bL32-R48)
* Added a debug log statement in `Chat.toChatUI` to help trace the value of `lastMessage?.time` during development.

**Imports:**

* Added imports for `android.util.Log`, `kotlinx.datetime.LocalDateTime`, and `kotlinx.datetime.number` to support the new functionality.