### PR TITLE
update customer home screen

### DIFF
--- a/app/src/main/java/com/paris_2/san3a/presentation/screen/home/customer/CustomerHomeScreen.kt
+++ b/app/src/main/java/com/paris_2/san3a/presentation/screen/home/customer/CustomerHomeScreen.kt
@@ -2,6 +2,7 @@ package com.paris_2.san3a.presentation.screen.home.customer
 
 import android.app.Activity
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.speech.RecognizerIntent
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResult
@@ -26,9 +27,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.paris_2.san3a.R
 import com.paris_2.san3a.presentation.screen.account.components.LocationBottomSheetContentType
@@ -78,6 +81,18 @@ private fun CustomerHomeScreenContent(
             action.addBottomSheetImages(newImages)
         }
     )
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            action.onMicClick()
+        } else {
+            // Show permission denied message or dialog
+        }
+    }
+
+    val context = LocalContext.current
 
     val voiceSearchPrompt = stringResource(R.string.voice_search)
 
@@ -337,7 +352,16 @@ private fun CustomerHomeScreenContent(
                         onValueChange = { action.onSearch(it) },
                         hint = stringResource(R.string.search),
                         onMicClick = {
-                            action.onMicClick()
+
+
+                            if (ContextCompat.checkSelfPermission(
+                                    context,
+                                    android.Manifest.permission.RECORD_AUDIO
+                                ) == PackageManager.PERMISSION_GRANTED) {
+                                action.onMicClick()
+                            } else {
+                                permissionLauncher.launch(android.Manifest.permission.RECORD_AUDIO)
+                            }
                         },
                         modifier = Modifier
                             .padding(top = 16.dp, bottom = 24.dp)


### PR DESCRIPTION
<img width="301" height="567" alt="image" src="https://github.com/user-attachments/assets/60d775da-f146-4371-8aac-cfab97849933" />
This pull request enhances the voice search feature in the `CustomerHomeScreen` by adding runtime permission handling for microphone access. Now, when the user taps the microphone icon, the app checks for the `RECORD_AUDIO` permission and requests it if not already granted.

**Voice Search Permission Handling:**

* Added imports for `PackageManager`, `LocalContext`, and `ContextCompat` to support runtime permission checks. [[1]](diffhunk://#diff-8ef47604b78951d1f467d332d5a1de941b6150d06796159d23449a2f41789e42R5) [[2]](diffhunk://#diff-8ef47604b78951d1f467d332d5a1de941b6150d06796159d23449a2f41789e42R30-R34)
* Introduced a `permissionLauncher` using `rememberLauncherForActivityResult` to request the `RECORD_AUDIO` permission and handle the result.
* Updated the `onMicClick` logic to check if the `RECORD_AUDIO` permission is granted; if not, it launches the permission request.