### PR TITLE
fix header date for messages

### DIFF
--- a/app/src/main/java/com/paris_2/san3a/presentation/screen/messagesDetails/MessageDetails.kt
+++ b/app/src/main/java/com/paris_2/san3a/presentation/screen/messagesDetails/MessageDetails.kt
@@ -143,6 +143,7 @@ fun MessageDetailsContent(
                 } else {
                     MessageList(
                         messages = state.messages,
+                        groupedMessages = state.groupedMessages,
                         modifier = Modifier
                             .fillMaxSize()
                             .padding(horizontal = 16.dp)
@@ -204,6 +205,7 @@ fun MessageDetailsContent(
 @Composable
 fun MessageList(
     messages: List<MessageUi>,
+    groupedMessages: Map<String, List<MessageUi>>, // Add parameter
     modifier: Modifier,
 ) {
     val listState = rememberLazyListState()
@@ -220,35 +222,38 @@ fun MessageList(
         contentPadding = PaddingValues(bottom = 80.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        item {
-            Text(
-                text = "9:23", // Todo(time of message )
-                style = Theme.textStyle.body.medium.regular,
-                color = Theme.colors.shade.tertiary,
-                textAlign = TextAlign.Center,
-                modifier = Modifier
-                    .padding(top = 10.dp)
-                    .fillMaxWidth()
-            )
-        }
-        items(messages) { item ->
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-            ) {
-                Message(
-                    images = item.images,
+        groupedMessages.forEach { (date, messagesForDate) ->
+            stickyHeader {
+                Text(
+                    text = date,
+                    style = Theme.textStyle.body.medium.regular,
+                    color = Theme.colors.shade.tertiary,
+                    textAlign = TextAlign.Center,
                     modifier = Modifier
-                        .align(if (item.isReceived) Alignment.CenterStart else Alignment.CenterEnd)
-                        .animateItem(),
-                    text = item.text,
-                    isReceived = item.isReceived,
-                    isSeen = item.isSeen,
-                    time = item.time,
-                    profileImageUrl = if (item.isReceived) item.anotherUserImage else null,
+                        .padding(top = 10.dp, bottom = 8.dp)
+                        .fillMaxWidth()
+                        .padding(8.dp)
                 )
             }
-            Spacer(modifier = Modifier.width(10.dp))
+
+            items(messagesForDate) { item ->
+                Box(
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Message(
+                        images = item.images,
+                        modifier = Modifier
+                            .align(if (item.isReceived) Alignment.CenterStart else Alignment.CenterEnd)
+                            .animateItem(),
+                        text = item.text,
+                        isReceived = item.isReceived,
+                        isSeen = item.isSeen,
+                        time = item.time,
+                        profileImageUrl = if (item.isReceived) item.anotherUserImage else null,
+                    )
+                }
+                Spacer(modifier = Modifier.width(10.dp))
+            }
         }
     }
 }

--- a/app/src/main/java/com/paris_2/san3a/presentation/screen/messagesDetails/MessageDetails.kt
+++ b/app/src/main/java/com/paris_2/san3a/presentation/screen/messagesDetails/MessageDetails.kt
@@ -205,7 +205,7 @@ fun MessageDetailsContent(
 @Composable
 fun MessageList(
     messages: List<MessageUi>,
-    groupedMessages: Map<String, List<MessageUi>>, // Add parameter
+    groupedMessages: Map<String, List<MessageUi>>,
     modifier: Modifier,
 ) {
     val listState = rememberLazyListState()

--- a/app/src/main/java/com/paris_2/san3a/presentation/screen/messagesDetails/MessageDetailsUiState.kt
+++ b/app/src/main/java/com/paris_2/san3a/presentation/screen/messagesDetails/MessageDetailsUiState.kt
@@ -56,8 +56,7 @@ private fun formatChatTime(time: LocalTime?): String {
     } ?: ""
 }
 
-@OptIn(ExperimentalTime::class)
-fun formatDateHeader(date: LocalDate): String {
+private fun formatDateHeader(date: LocalDate): String {
     val javaLocalDate = java.time.LocalDate.of(date.year, date.month.number, date.day)
     return  javaLocalDate.format(DateTimeFormatter.ofPattern("MMM dd, yyyy"))
 }

--- a/app/src/main/java/com/paris_2/san3a/presentation/screen/messagesDetails/MessageDetailsUiState.kt
+++ b/app/src/main/java/com/paris_2/san3a/presentation/screen/messagesDetails/MessageDetailsUiState.kt
@@ -3,6 +3,12 @@ package com.paris_2.san3a.presentation.screen.messagesDetails
 import com.paris_2.san3a.domain.entity.Message
 import com.paris_2.san3a.domain.entity.MessageContent
 import com.paris_2.san3a.presentation.shared.components.AppButtonState
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.number
+import java.time.format.DateTimeFormatter
+import kotlin.time.ExperimentalTime
+
 
 data class MessageDetailsUiState(
     val textMessage: String = "",
@@ -10,6 +16,7 @@ data class MessageDetailsUiState(
     val chatTitle: String = "",
     val profilePhoto: String = "",
     val showDropMenu: Boolean = false,
+    val groupedMessages: Map<String, List<MessageUi>> = emptyMap(),
     val showDeleteChatBottomSheet: Boolean = false,
     val bottomSheetButtonState: AppButtonState = AppButtonState.Enable,
     val errorMessage: String? = null,
@@ -21,6 +28,7 @@ data class MessageUi(
     val images: List<String> = emptyList(),
     val anotherUserImage: String,
     val time: String,
+    val date: String,
     val isReceived: Boolean = false,
     val isSeen: Boolean = false,
 )
@@ -30,20 +38,28 @@ fun Message.toMessageUi(imageUserUrl: String, currentUserId: String) = MessageUi
     images = handleImagesMessage(messageContent),
     anotherUserImage = imageUserUrl,
     time = formatChatTime(this.time.time),
+    date = formatDateHeader(this.time.date),
     isReceived = this.receiverId == currentUserId,
     isSeen = this.seen,
 )
 
-private fun formatChatTime(time: kotlinx.datetime.LocalTime?): String {
+
+private fun formatChatTime(time: LocalTime?): String {
     return time?.let {
         try {
-            val outputFormat = java.time.format.DateTimeFormatter.ofPattern("hh:mm a")
+            val outputFormat = DateTimeFormatter.ofPattern("hh:mm a")
             val javaLocalTime = java.time.LocalTime.of(it.hour, it.minute, it.second, it.nanosecond)
             javaLocalTime.format(outputFormat)
         } catch (e: Exception) {
             ""
         }
     } ?: ""
+}
+
+@OptIn(ExperimentalTime::class)
+fun formatDateHeader(date: LocalDate): String {
+    val javaLocalDate = java.time.LocalDate.of(date.year, date.month.number, date.day)
+    return  javaLocalDate.format(DateTimeFormatter.ofPattern("MMM dd, yyyy"))
 }
 
 fun handleTextMessage(messageContent: MessageContent): String {

--- a/app/src/main/java/com/paris_2/san3a/presentation/screen/messagesDetails/MessagesDetailsViewModel.kt
+++ b/app/src/main/java/com/paris_2/san3a/presentation/screen/messagesDetails/MessagesDetailsViewModel.kt
@@ -77,12 +77,18 @@ class MessagesDetailsViewModel(
             },
             onSuccess = { flowMessages ->
                 flowMessages.collect { messages ->
+                    val groupedMessages = messages
+                        .map { it.toMessageUi(screenState.value.profilePhoto, currentUserId) }
+                        .groupBy { it.date }
+                        .toSortedMap(compareBy { it })
+
                     updateState(
                         screenState.value.copy(
                             messages = messages.map { it.toMessageUi(screenState.value.profilePhoto, currentUserId) },
+                            groupedMessages = groupedMessages,
                             chatTitle = screenState.value.chatTitle,
                             isLoading = false
-                        ),
+                        )
                     )
                     markMessagesAsSeen()
                 }
@@ -94,7 +100,7 @@ class MessagesDetailsViewModel(
                         isLoading = false
                     )
                 )
-            },
+            }
         )
     }
 

--- a/app/src/main/java/com/paris_2/san3a/presentation/screen/messagesDetails/MessagesDetailsViewModel.kt
+++ b/app/src/main/java/com/paris_2/san3a/presentation/screen/messagesDetails/MessagesDetailsViewModel.kt
@@ -70,28 +70,27 @@ class MessagesDetailsViewModel(
     }
 
     private fun loadMessages(chatId: String) {
-        tryToExecute(
-            execute = {
+        tryToObserve(
+            observe = {
                 updateState(screenState.value.copy(isLoading = true))
                 getMessagesByChatIdUseCase(chatId)
             },
-            onSuccess = { flowMessages ->
-                flowMessages.collect { messages ->
-                    val groupedMessages = messages
-                        .map { it.toMessageUi(screenState.value.profilePhoto, currentUserId) }
-                        .groupBy { it.date }
-                        .toSortedMap(compareBy { it })
+            onEach = { messages ->
+                val messageUis =
+                    messages.map { it.toMessageUi(screenState.value.profilePhoto, currentUserId) }
+                val groupedMessages = messageUis
+                    .groupBy { it.date }
+                    .toSortedMap(compareBy { it })
 
-                    updateState(
-                        screenState.value.copy(
-                            messages = messages.map { it.toMessageUi(screenState.value.profilePhoto, currentUserId) },
-                            groupedMessages = groupedMessages,
-                            chatTitle = screenState.value.chatTitle,
-                            isLoading = false
-                        )
+                updateState(
+                    screenState.value.copy(
+                        messages = messageUis,
+                        groupedMessages = groupedMessages,
+                        chatTitle = screenState.value.chatTitle,
+                        isLoading = false
                     )
-                    markMessagesAsSeen()
-                }
+                )
+                markMessagesAsSeen()
             },
             onError = {
                 updateState(


### PR DESCRIPTION

[Screencast from 08-08-2025 12:06:30 PM.webm](https://github.com/user-attachments/assets/57a4a6c0-b2fc-4b7a-9263-9e9f171ec524)

This pull request enhances the message details screen by introducing grouped message display with date headers, making the chat UI clearer and more organized. The main changes involve updating the UI state and message list rendering to support grouping messages by date, and refactoring data models and formatting utilities accordingly.

**UI and State Management Improvements:**

* Added a new `groupedMessages` property to `MessageDetailsUiState` to store messages grouped by date, and updated the ViewModel to populate this property by grouping messages using their formatted date. [[1]](diffhunk://#diff-e284efd9df642d59b056ba682fc0516e5f49eeb566f46c3dce5bcdc41d1f991bR6-R19) [[2]](diffhunk://#diff-e96327843c89c52f284027719f85d627765465245cb383c13ad6ab8233539d8fR80-R91)
* Updated the `MessageUi` data class and mapping logic to include a `date` field, used for grouping and displaying date headers. [[1]](diffhunk://#diff-e284efd9df642d59b056ba682fc0516e5f49eeb566f46c3dce5bcdc41d1f991bR31) [[2]](diffhunk://#diff-e284efd9df642d59b056ba682fc0516e5f49eeb566f46c3dce5bcdc41d1f991bR41-R50)

**UI Rendering Enhancements:**

* Modified the `MessageList` composable to accept `groupedMessages` and render messages grouped by date, with a sticky header for each date group. The message time and date formatting logic was also improved for display. [[1]](diffhunk://#diff-049620e9cd723d92b949c88a54086ec0c4fcd99015ee055d2f1512bb19caf32cR146) [[2]](diffhunk://#diff-049620e9cd723d92b949c88a54086ec0c4fcd99015ee055d2f1512bb19caf32cR208) [[3]](diffhunk://#diff-049620e9cd723d92b949c88a54086ec0c4fcd99015ee055d2f1512bb19caf32cL223-R241)

**Formatting Utilities:**

* Added the `formatDateHeader` function to format date headers for message grouping, and refactored time formatting to use shared utilities.