### PR TITLE
Order craftsman requests by creation date

### DIFF
--- a/app/src/main/java/com/paris_2/san3a/data/source/remote/user/UserRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/paris_2/san3a/data/source/remote/user/UserRemoteDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.paris_2.san3a.data.source.remote.user
 
 import android.util.Log
 import com.google.firebase.firestore.FieldPath
+import com.google.firebase.firestore.Query
 import com.paris_2.san3a.data.service.firestore.FireStoreService
 import com.paris_2.san3a.data.service.firestore.SetOperation
 import com.paris_2.san3a.data.service.firestore.WriteOperation
@@ -263,7 +264,9 @@ class UserRemoteDataSourceImpl(
             path = SERVICE_REQUESTS_COLLECTION,
             fromJson = RequestServiceDto::fromJson,
             queryBuilder = { query ->
-                query.whereIn("title", relatedJobs)
+                query
+                    .whereIn("serviceId", relatedJobs)
+                    .orderBy("createdAt", Query.Direction.DESCENDING)
             }
         )
     }

--- a/app/src/main/java/com/paris_2/san3a/data/source/remote/user/dto/RequestServiceDto.kt
+++ b/app/src/main/java/com/paris_2/san3a/data/source/remote/user/dto/RequestServiceDto.kt
@@ -16,7 +16,8 @@ data class RequestServiceDto(
     val userId: String,
     val serviceId: String,
     val selectedCraftsmanId: String?,
-    val requestStatus: String?
+    val requestStatus: String?,
+    val createdAt: Long = System.currentTimeMillis(),
 ) {
     companion object {
         fun fromJson(data: Map<String, Any>, id: String): RequestServiceDto {
@@ -34,7 +35,8 @@ data class RequestServiceDto(
                 userId = data["userId"] as? String ?: "",
                 serviceId = data["serviceId"] as? String ?: "",
                 selectedCraftsmanId = data["selectedCraftsmanId"] as? String,
-                requestStatus = data["requestStatus"] as? String
+                requestStatus = data["requestStatus"] as? String,
+                createdAt = (data["createdAt"] as? Number)?.toLong() ?: System.currentTimeMillis()
             )
         }
     }
@@ -51,6 +53,7 @@ data class RequestServiceDto(
             "userId" to userId,
             "serviceId" to serviceId,
             "state" to state,
+            "createdAt" to createdAt
         )
         if (selectedCraftsmanId != null) {
             map["selectedCraftsmanId"] = selectedCraftsmanId

--- a/app/src/main/java/com/paris_2/san3a/presentation/screen/home/craftsman/CraftsmanHomeViewModel.kt
+++ b/app/src/main/java/com/paris_2/san3a/presentation/screen/home/craftsman/CraftsmanHomeViewModel.kt
@@ -41,9 +41,7 @@ class CraftsmanHomeViewModel(
                 updateState(
                     screenState.value.copy(
                         craftsmanHomeUiState = screenState.value.craftsmanHomeUiState.copy(
-                            userServices = services?.map {
-                                it.title[currentLocale] ?: it.title.values.firstOrNull() ?: ""
-                            } ?: emptyList(),
+                            userServices = services?.map { it.id } ?: emptyList(),
                         )
                     )
                 )


### PR DESCRIPTION
- Add `createdAt` field to `RequestServiceDto` to store the creation timestamp of a service request.
- Update `UserRemoteDataSourceImpl` to order craftsman requests by `createdAt` in descending order.
- Modify `CraftsmanHomeViewModel` to use service IDs instead of titles for `userServices`.