### PR TITLE
refactor/account-ui

### DIFF
--- a/app/src/main/java/com/paris_2/san3a/presentation/screen/account/AccountScreen.kt
+++ b/app/src/main/java/com/paris_2/san3a/presentation/screen/account/AccountScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import com.paris_2.san3a.presentation.screen.account.components.AccountAppButton
 import com.paris_2.san3a.presentation.screen.account.components.AccountProgressIndicator
 import com.paris_2.san3a.presentation.screen.account.components.AccountTypeContent
 import com.paris_2.san3a.presentation.screen.account.components.LocationContent
@@ -31,20 +32,12 @@ import com.paris_2.san3a.presentation.screen.account.components.ServicesContent
 import com.paris_2.san3a.presentation.screen.account.components.ShowYourWorkContent
 import com.paris_2.san3a.presentation.screen.account.components.VerifyIdentityContent
 import com.paris_2.san3a.presentation.shared.components.AppBackButton
-import com.paris_2.san3a.presentation.shared.components.AppButton
-import com.paris_2.san3a.presentation.shared.components.AppButtonSize
-import com.paris_2.san3a.presentation.shared.components.AppButtonType
-import com.paris_2.san3a.presentation.shared.components.LoadingScreen
 import com.paris_2.san3a.presentation.shared.designSystem.theme.Theme
 import com.paris_2.san3a.presentation.shared.utils.asString
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
 fun AccountScreen(viewModel: AccountViewModel = koinViewModel()) {
-    val progress = viewModel.progress
-    val title = viewModel.getTitle()
-    val description = viewModel.getDescription()
-    val textButton = viewModel.getButtonText()
     val currentScreen by viewModel.currentScreen
     val uiState by viewModel.screenState.collectAsState()
     val context = LocalContext.current
@@ -94,11 +87,11 @@ fun AccountScreen(viewModel: AccountViewModel = koinViewModel()) {
     }
 
     AccountScreenContent(
-        title = title.asString(),
-        description = description.asString(),
-        textButton = textButton.asString(),
+        title = viewModel.getTitle().asString(),
+        description = viewModel.getDescription().asString(),
+        textButton = viewModel.getButtonText().asString(),
         currentScreen = currentScreen,
-        progress = progress,
+        progress = viewModel.progress,
         onCustomerProfilePhotoClick = { profileImagePickerLauncher.launch(arrayOf("image/*")) },
         onFrontNationalIdClick = { frontNationalIdPickerLauncher.launch(arrayOf("image/*")) },
         onBackNationalIdClick = { backNationalIdPickerLauncher.launch(arrayOf("image/*")) },
@@ -123,17 +116,13 @@ fun AccountScreenContent(
     uiState: AccountScreenUiState,
     modifier: Modifier = Modifier,
 ) {
-
-
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier
             .fillMaxSize()
             .background(Theme.colors.background.screen)
             .safeContentPadding()
-            .padding(top = 16.dp, bottom = 16.dp)
-            .padding(horizontal = 16.dp)
-
+            .padding(horizontal = 16.dp, vertical = 16.dp)
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -151,7 +140,9 @@ fun AccountScreenContent(
             text = title,
             color = Theme.colors.shade.primary,
             style = Theme.textStyle.display.xLarge,
-            modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp)
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 16.dp)
         )
         Text(
             text = description,
@@ -165,20 +156,10 @@ fun AccountScreenContent(
                     onUserTypeSelected = interactionListener::onUserTypeSelected,
                     selectedType = uiState.accountUiState.userType
                 )
-
-                AppButton(
-                    onClick = interactionListener::onUserTypeButtonClicked,
-                    type = AppButtonType.Primary,
-                    text = textButton,
-                    state = uiState.accountUiState.accountButtonState.userTypeButtonState,
-                    modifier = Modifier.fillMaxWidth(),
-                    size = AppButtonSize.Large,
-                    loadingIcon = {
-                        LoadingScreen(
-                            modifier = modifier.size(25.dp),
-                            background = Theme.colors.button.primary
-                        )
-                    }
+                AccountAppButton(
+                    onClickButton = interactionListener::onUserTypeButtonClicked,
+                    textButton = textButton,
+                    state = uiState.accountUiState.accountButtonState.userTypeButtonState
                 )
             }
 
@@ -188,19 +169,10 @@ fun AccountScreenContent(
                     onChipClick = interactionListener::onToggleServiceClicked,
                     modifier = Modifier.padding(vertical = 32.dp)
                 )
-                AppButton(
-                    onClick = interactionListener::onServiceButtonClicked,
-                    type = AppButtonType.Primary,
-                    text = textButton,
-                    state = uiState.accountUiState.accountButtonState.serviceButtonState,
-                    modifier = Modifier.fillMaxWidth(),
-                    size = AppButtonSize.Large,
-                    loadingIcon = {
-                        LoadingScreen(
-                            modifier = modifier.size(25.dp),
-                            background = Theme.colors.button.primary
-                        )
-                    }
+                AccountAppButton(
+                    onClickButton = interactionListener::onServiceButtonClicked,
+                    textButton = textButton,
+                    state = uiState.accountUiState.accountButtonState.serviceButtonState
                 )
             }
 
@@ -212,19 +184,10 @@ fun AccountScreenContent(
                     onAddPhotoClick = onCustomerProfilePhotoClick,
                     profilePhotoUri = uiState.accountUiState.customerProfilePhotoUri
                 )
-                AppButton(
-                    onClick = interactionListener::onProfileButtonClicked,
-                    type = AppButtonType.Primary,
-                    text = textButton,
-                    state = uiState.accountUiState.accountButtonState.profileButtonState,
-                    modifier = Modifier.fillMaxWidth(),
-                    size = AppButtonSize.Large,
-                    loadingIcon = {
-                        LoadingScreen(
-                            modifier = modifier.size(25.dp),
-                            background = Theme.colors.button.primary
-                        )
-                    }
+                AccountAppButton(
+                    onClickButton = interactionListener::onProfileButtonClicked,
+                    textButton = textButton,
+                    state = uiState.accountUiState.accountButtonState.profileButtonState
                 )
             }
 
@@ -247,22 +210,12 @@ fun AccountScreenContent(
                         onAddressDetailsChange = interactionListener::onAddressDetailsChanged,
                         locationBottomSheetContentType = uiState.accountUiState.locationType
                     )
-                    AppButton(
-                        onClick = interactionListener::onLocationButtonClicked,
-                        type = AppButtonType.Primary,
-                        text = textButton,
-                        state = uiState.accountUiState.accountButtonState.locationButtonState,
-                        modifier = Modifier.fillMaxWidth(),
-                        size = AppButtonSize.Large,
-                        loadingIcon = {
-                            LoadingScreen(
-                                modifier = modifier.size(25.dp),
-                                background = Theme.colors.button.primary
-                            )
-                        }
+                    AccountAppButton(
+                        onClickButton = interactionListener::onLocationButtonClicked,
+                        textButton = textButton,
+                        state = uiState.accountUiState.accountButtonState.locationButtonState
                     )
                 }
-
                 UserType.CRAFTSMAN -> {
                     ShowYourWorkContent(
                         modifier = Modifier.padding(vertical = 32.dp),
@@ -272,30 +225,18 @@ fun AccountScreenContent(
                         onDescriptionChanged = interactionListener::onDescriptionChanged,
                         onDeleteImage = interactionListener::onDeleteWorkImageClicked
                     )
-                    AppButton(
-                        onClick = interactionListener::onShowWorkButtonClicked,
-                        type = AppButtonType.Primary,
-                        text = textButton,
-                        state = uiState.accountUiState.accountButtonState.workShowCaseButtonState,
-                        modifier = Modifier.fillMaxWidth(),
-                        size = AppButtonSize.Large,
-                        loadingIcon = {
-                            LoadingScreen(
-                                modifier = modifier.size(25.dp),
-                                background = Theme.colors.button.primary
-                            )
-                        }
-
+                    AccountAppButton(
+                        onClickButton = interactionListener::onShowWorkButtonClicked,
+                        textButton = textButton,
+                        state = uiState.accountUiState.accountButtonState.workShowCaseButtonState
                     )
                 }
-
                 else -> {}
             }
 
             4 -> when (uiState.accountUiState.userType) {
                 UserType.CRAFTSMAN -> {
                     VerifyIdentityContent(
-
                         modifier = Modifier.padding(
                             top = 32.dp, bottom = 12.dp
                         ),
@@ -305,27 +246,13 @@ fun AccountScreenContent(
                         backOfNationalIdUri = uiState.accountUiState.backOfNationalIdUri,
                         onVerifyLaterClick = interactionListener::onVerifyIdentityButtonClicked
                     )
-
-                    AppButton(
-                        onClick = interactionListener::onVerifyIdentityButtonClicked,
-                        type = AppButtonType.Primary,
-                        text = textButton,
-                        state = uiState.accountUiState.accountButtonState.verifyIdentityButtonState,
-                        modifier = Modifier.fillMaxWidth(),
-                        size = AppButtonSize.Large,
-                        loadingIcon = {
-                            LoadingScreen(
-                                modifier.size(25.dp),
-                                background = Theme.colors.button.primary
-                            )
-                        }
-
+                    AccountAppButton(
+                        onClickButton = interactionListener::onVerifyIdentityButtonClicked,
+                        textButton = textButton,
+                        state = uiState.accountUiState.accountButtonState.verifyIdentityButtonState
                     )
-
                 }
-
-                else -> {
-                }
+                else -> {}
             }
         }
     }

--- a/app/src/main/java/com/paris_2/san3a/presentation/screen/account/AccountViewModel.kt
+++ b/app/src/main/java/com/paris_2/san3a/presentation/screen/account/AccountViewModel.kt
@@ -14,6 +14,7 @@ import com.paris_2.san3a.domain.entity.AccountType
 import com.paris_2.san3a.domain.entity.City
 import com.paris_2.san3a.domain.entity.Governorate
 import com.paris_2.san3a.domain.entity.Service
+import com.paris_2.san3a.domain.entity.User
 import com.paris_2.san3a.domain.usecase.GetAllServicesUseCase
 import com.paris_2.san3a.domain.usecase.GetLocationInfoUseCase
 import com.paris_2.san3a.domain.usecase.GetPhoneNumberUseCase
@@ -26,6 +27,7 @@ import com.paris_2.san3a.presentation.screen.account.components.LocationBottomSh
 import com.paris_2.san3a.presentation.shared.components.AppButtonState
 import com.paris_2.san3a.presentation.shared.utils.BaseViewModel
 import com.paris_2.san3a.presentation.shared.utils.UiText
+import kotlinx.coroutines.flow.Flow
 
 class AccountViewModel(
     private val getLocationInfoUseCase: GetLocationInfoUseCase,
@@ -62,48 +64,39 @@ class AccountViewModel(
     private fun getPhoneNumber() {
         tryToExecute(
             execute = { getPhoneNumberUseCase() },
-            onSuccess = { phoneNumber ->
-                updateState(
-                    screenState.value.copy(
-                        accountUiState = screenState.value.accountUiState.copy(
-                            phoneNumber = phoneNumber
-                        )
-                    )
-                )
-                loadUserAndGoToLastStep()
-                getUserSelectedServices()
-                getWorkMedia()
-            },
-            onError = { errorMessage ->
-                updateState(
-                    screenState.value.copy(
-                        errorMassage = errorMessage.message,
-                    )
-                )
-            },
+            onSuccess = ::onGetPhoneNumberSuccess,
+            onError = ::onError,
         )
+    }
+
+    private fun onGetPhoneNumberSuccess(phoneNumber: String) {
+        updateState(
+            screenState.value.copy(
+                accountUiState = screenState.value.accountUiState.copy(
+                    phoneNumber = phoneNumber
+                )
+            )
+        )
+        loadUserAndGoToLastStep()
+        getUserSelectedServices()
+        getWorkMedia()
     }
 
     private fun getWorkMedia() {
         tryToExecute(
             execute = { setUpAccountUseCase.getWorkMedia(screenState.value.accountUiState.phoneNumber) },
-            onSuccess = { workMedia ->
-                updateState(
-                    screenState.value.copy(
-                        accountUiState = screenState.value.accountUiState.copy(
-                            workImagesUris = workMedia.map { it.toUri() }
-                        )
-                    )
+            onSuccess = ::onGetWorkMediaSuccess,
+            onError = ::onError
+        )
+    }
+
+    private fun onGetWorkMediaSuccess(workMedia: List<String>) {
+        updateState(
+            screenState.value.copy(
+                accountUiState = screenState.value.accountUiState.copy(
+                    workImagesUris = workMedia.map { it.toUri() }
                 )
-            },
-            onError = { errorMessage ->
-                updateState(
-                    screenState.value.copy(
-                        errorMassage = errorMessage.message,
-                        isLoading = false
-                    )
-                )
-            }
+            )
         )
     }
 
@@ -115,122 +108,101 @@ class AccountViewModel(
                     isCraftsman = screenState.value.accountUiState.userType == UserType.CRAFTSMAN
                 )
             },
-            onEach = { services ->
-                val serviceUiStates = mapServiceToUiState(services ?: emptyList())
-                updateState(
-                    screenState.value.copy(
-                        accountUiState = screenState.value.accountUiState.copy(
-                            serviceUiState = screenState.value.accountUiState.serviceUiState.map { service ->
-                                service.copy(isSelected = serviceUiStates.any { service.id == it.id })
-                            },
-                            accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
-                                serviceButtonState = if (serviceUiStates.isNotEmpty()) AppButtonState.Enable else AppButtonState.Disabled
+            onEach = ::onGetUserSelectedServicesEach,
+            onError = ::onError
+        )
+    }
 
-                            )
-                        )
+    private fun onGetUserSelectedServicesEach(services: List<Service>?) {
+        val serviceUiStates = mapServiceToUiState(services ?: emptyList())
+        updateState(
+            screenState.value.copy(
+                accountUiState = screenState.value.accountUiState.copy(
+                    serviceUiState = screenState.value.accountUiState.serviceUiState.map { service ->
+                        service.copy(isSelected = serviceUiStates.any { service.id == it.id })
+                    },
+                    accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
+                        serviceButtonState = if (serviceUiStates.isNotEmpty()) AppButtonState.Enable
+                        else AppButtonState.Disabled
                     )
                 )
-            },
-            onError = { errorMessage ->
-                updateState(
-                    screenState.value.copy(
-                        errorMassage = errorMessage.message,
-                        isLoading = false,
-                    )
-                )
-            }
+            )
         )
     }
 
     private fun loadUserAndGoToLastStep() {
         tryToExecute(
             execute = { getUserUseCase(screenState.value.accountUiState.phoneNumber) },
-            onSuccess = { user ->
-                updateState(
-                    screenState.value.copy(
-                        accountUiState = screenState.value.accountUiState.copy(
-                            userType = UserType.valueOf(user.accountType.name),
-                            locationUiState = user.location.toUiState(
-                                getLocationInfoUseCase.getGovernorateById(user.location.governmentId),
-                                getLocationInfoUseCase.getCityById(user.location.cityId)
-                            ),
-                            customerName = user.fullName,
-                            customerProfilePhotoUri = if (user.profilePhoto.isNotBlank()) user.profilePhoto.toUri() else null,
-                            frontOfNationalIdUri = if (user.nationalIdFrontImage.isNotBlank()) user.nationalIdFrontImage.toUri() else null,
-                            backOfNationalIdUri = if (user.nationalIdBackImage.isNotBlank()) user.nationalIdBackImage.toUri() else null,
-                            workDescription = user.workDescription,
-                            accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
-                                userTypeButtonState = if (user.accountType.name.isNotBlank()) AppButtonState.Enable else AppButtonState.Disabled,
-                                profileButtonState = if (user.fullName.isNotBlank()) AppButtonState.Enable else AppButtonState.Disabled,
-                                locationButtonState = if (user.location.governmentId == 0) AppButtonState.Enable else AppButtonState.Disabled,
-                                verifyIdentityButtonState = if (user.nationalIdBackImage.isNotBlank() && user.nationalIdFrontImage.isNotEmpty()) AppButtonState.Enable else AppButtonState.Disabled,
-                            )
-                        )
-                    )
-                )
-                _currentScreen.intValue = when (accountSetupStep) {
-                    AccountSetupStep.ACCOUNT_TYPE -> 0
-                    AccountSetupStep.SERVICES -> 1
-                    AccountSetupStep.PERSONAL_INFO -> 2
-                    AccountSetupStep.LOCATION, AccountSetupStep.WORK_SHOWCASE -> 3
-                    AccountSetupStep.UPLOAD_NATIONAL_ID -> 4
-                    AccountSetupStep.COMPLETED -> 5
-                }
-            },
-            onError = { errorMessage ->
-                updateState(
-                    screenState.value.copy(
-                        errorMassage = errorMessage.message,
-                        isLoading = false
-                    )
-                )
-            }
+            onSuccess = ::onLoadUserAndGoToLastStepSuccess,
+            onError = ::onError
         )
+    }
+
+    private suspend fun onLoadUserAndGoToLastStepSuccess(user: User) {
+        updateState(
+            screenState.value.copy(
+                accountUiState = screenState.value.accountUiState.copy(
+                    userType = UserType.valueOf(user.accountType.name),
+                    locationUiState = user.location.toUiState(
+                        getLocationInfoUseCase.getGovernorateById(user.location.governmentId),
+                        getLocationInfoUseCase.getCityById(user.location.cityId)
+                    ),
+                    customerName = user.fullName,
+                    customerProfilePhotoUri = if (user.profilePhoto.isNotBlank()) user.profilePhoto.toUri() else null,
+                    frontOfNationalIdUri = if (user.nationalIdFrontImage.isNotBlank()) user.nationalIdFrontImage.toUri() else null,
+                    backOfNationalIdUri = if (user.nationalIdBackImage.isNotBlank()) user.nationalIdBackImage.toUri() else null,
+                    workDescription = user.workDescription,
+                    accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
+                        userTypeButtonState = if (user.accountType.name.isNotBlank()) AppButtonState.Enable else AppButtonState.Disabled,
+                        profileButtonState = if (user.fullName.isNotBlank()) AppButtonState.Enable else AppButtonState.Disabled,
+                        locationButtonState = if (user.location.governmentId == 0) AppButtonState.Enable else AppButtonState.Disabled,
+                        verifyIdentityButtonState = if (user.nationalIdBackImage.isNotBlank() && user.nationalIdFrontImage.isNotEmpty()) AppButtonState.Enable else AppButtonState.Disabled,
+                    )
+                )
+            )
+        )
+        getAccountSetupStep()
+    }
+
+    private fun getAccountSetupStep() {
+        _currentScreen.intValue = when (accountSetupStep) {
+            AccountSetupStep.ACCOUNT_TYPE -> 0
+            AccountSetupStep.SERVICES -> 1
+            AccountSetupStep.PERSONAL_INFO -> 2
+            AccountSetupStep.LOCATION, AccountSetupStep.WORK_SHOWCASE -> 3
+            AccountSetupStep.UPLOAD_NATIONAL_ID -> 4
+            AccountSetupStep.COMPLETED -> 5
+        }
     }
 
     private fun getAllServices() {
         updateState(screenState.value.copy(isLoading = true))
-
         tryToExecute(
             execute = { getAllServicesUseCase() },
-            onSuccess = { services ->
-                services.collect {
-                    val serviceUiStates = mapServiceToUiState(it)
-                    updateState(
-                        screenState.value.copy(
-                            accountUiState = screenState.value.accountUiState.copy(
-                                serviceUiState = serviceUiStates
-                            ),
-                            isLoading = false,
-                            errorMassage = null
-                        )
-                    )
-                }
-
-            },
-            onError = { errorMessage ->
-                updateState(
-                    screenState.value.copy(
-                        errorMassage = errorMessage.message,
-                        isLoading = false
-                    )
-                )
-            },
+            onSuccess = ::onGetAllServicesSuccess,
+            onError = ::onError,
         )
+    }
+
+    private suspend fun onGetAllServicesSuccess(services: Flow<List<Service>>) {
+        services.collect {
+            val serviceUiStates = mapServiceToUiState(it)
+            updateState(
+                screenState.value.copy(
+                    accountUiState = screenState.value.accountUiState.copy(
+                        serviceUiState = serviceUiStates
+                    ),
+                    isLoading = false,
+                    errorMassage = null
+                )
+            )
+        }
     }
 
     override fun onToggleServiceClicked(serviceId: String) {
         val updatedServices = screenState.value.accountUiState.serviceUiState.map {
             if (it.id == serviceId) {
-                updateState(
-                    screenState.value.copy(
-                        accountUiState = screenState.value.accountUiState.copy(
-                            accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
-                                serviceButtonState = AppButtonState.Enable
-                            )
-                        )
-                    )
-                )
+                changeAppButtonStateInService(AppButtonState.Enable)
                 it.copy(isSelected = !it.isSelected)
             } else {
                 it
@@ -245,30 +217,13 @@ class AccountViewModel(
         )
 
         if (screenState.value.accountUiState.serviceUiState.any { it.isSelected }) {
-            updateState(
-                screenState.value.copy(
-                    accountUiState = screenState.value.accountUiState.copy(
-                        accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
-                            serviceButtonState = AppButtonState.Enable
-                        )
-                    )
-                )
-            )
+            changeAppButtonStateInService(AppButtonState.Enable)
         } else {
-            updateState(
-                screenState.value.copy(
-                    accountUiState = screenState.value.accountUiState.copy(
-                        accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
-                            serviceButtonState = AppButtonState.Disabled
-                        )
-                    )
-                )
-            )
+            changeAppButtonStateInService(AppButtonState.Disabled)
         }
     }
 
     override fun onUserTypeSelected(type: UserType) {
-        // need to observe the state of current item
         Log.d("AccountSetup", "onUserTypeSelected: ${type.name}")
         val updatedUiState = screenState.value.copy(
             accountUiState = screenState.value.accountUiState.copy(
@@ -290,25 +245,9 @@ class AccountViewModel(
             )
         )
         if (screenState.value.accountUiState.customerName.isNotBlank()) {
-            updateState(
-                screenState.value.copy(
-                    accountUiState = screenState.value.accountUiState.copy(
-                        accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
-                            profileButtonState = AppButtonState.Enable
-                        )
-                    )
-                )
-            )
+            changeAppButtonStateInProfile(AppButtonState.Enable)
         } else {
-            updateState(
-                screenState.value.copy(
-                    accountUiState = screenState.value.accountUiState.copy(
-                        accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
-                            profileButtonState = AppButtonState.Disabled
-                        )
-                    )
-                )
-            )
+            changeAppButtonStateInProfile(AppButtonState.Disabled)
         }
     }
 
@@ -341,15 +280,7 @@ class AccountViewModel(
             )
         )
         if (screenState.value.accountUiState.backOfNationalIdUri != null)
-            updateState(
-                screenState.value.copy(
-                    accountUiState = screenState.value.accountUiState.copy(
-                        accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
-                            verifyIdentityButtonState = AppButtonState.Enable
-                        )
-                    )
-                )
-            )
+            changeAppButtonStateInVerifyIdentity(AppButtonState.Enable)
     }
 
     fun onBackNationalIdSelected(uri: Uri) {
@@ -361,19 +292,10 @@ class AccountViewModel(
             )
         )
         if (screenState.value.accountUiState.frontOfNationalIdUri != null)
-            updateState(
-                screenState.value.copy(
-                    accountUiState = screenState.value.accountUiState.copy(
-                        accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
-                            verifyIdentityButtonState = AppButtonState.Enable
-                        )
-                    )
-                )
-            )
+            changeAppButtonStateInVerifyIdentity(AppButtonState.Enable)
     }
 
     fun onWorkImageSelected(uris: List<Uri>) {
-
         val lastWorkImagesUris = screenState.value.accountUiState.workImagesUris
 
         val filteredUris = uris.filter { uri ->
@@ -391,17 +313,8 @@ class AccountViewModel(
         )
 
         if (!screenState.value.accountUiState.workImagesUris.isNullOrEmpty()) {
-            updateState(
-                screenState.value.copy(
-                    accountUiState = screenState.value.accountUiState.copy(
-                        accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
-                            workShowCaseButtonState = AppButtonState.Enable
-                        )
-                    )
-                )
-            )
+            changeAppButtonStateInWorkShowCase(AppButtonState.Enable)
         }
-
     }
 
     override fun onDeleteWorkImageClicked(uri: Uri) {
@@ -413,15 +326,7 @@ class AccountViewModel(
             )
         )
         if (screenState.value.accountUiState.workImagesUris.isNullOrEmpty()) {
-            updateState(
-                screenState.value.copy(
-                    accountUiState = screenState.value.accountUiState.copy(
-                        accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
-                            workShowCaseButtonState = AppButtonState.Disabled
-                        )
-                    )
-                )
-            )
+            changeAppButtonStateInWorkShowCase(AppButtonState.Disabled)
         }
     }
 
@@ -432,52 +337,20 @@ class AccountViewModel(
         when (_currentScreen.intValue) {
             1 -> {
                 if (screenState.value.accountUiState.serviceUiState.isNotEmpty())
-                    updateState(
-                        screenState.value.copy(
-                            accountUiState = screenState.value.accountUiState.copy(
-                                accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
-                                    serviceButtonState = AppButtonState.Enable
-                                )
-                            )
-                        )
-                    )
+                    changeAppButtonStateInService(AppButtonState.Enable)
             }
 
             2 -> {
                 if (screenState.value.accountUiState.customerName.isBlank()) {
-                    updateState(
-                        screenState.value.copy(
-                            accountUiState = screenState.value.accountUiState.copy(
-                                accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
-                                    profileButtonState = AppButtonState.Disabled
-                                )
-                            )
-                        )
-                    )
+                    changeAppButtonStateInProfile(AppButtonState.Disabled)
                 } else {
-                    updateState(
-                        screenState.value.copy(
-                            accountUiState = screenState.value.accountUiState.copy(
-                                accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
-                                    profileButtonState = AppButtonState.Enable
-                                )
-                            )
-                        )
-                    )
+                    changeAppButtonStateInProfile(AppButtonState.Enable)
                 }
             }
 
             3 -> {
                 if (!screenState.value.accountUiState.workImagesUris.isNullOrEmpty()) {
-                    updateState(
-                        screenState.value.copy(
-                            accountUiState = screenState.value.accountUiState.copy(
-                                accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
-                                    workShowCaseButtonState = AppButtonState.Enable
-                                )
-                            )
-                        )
-                    )
+                    changeAppButtonStateInWorkShowCase(AppButtonState.Enable)
                 }
             }
 
@@ -495,7 +368,6 @@ class AccountViewModel(
             }
 
             2 -> UiText.StringResource(R.string.personalize_your_profile)
-
             3 -> when (screenState.value.accountUiState.userType) {
                 UserType.CUSTOMER -> UiText.StringResource(R.string.where_are_you_located)
                 UserType.CRAFTSMAN -> UiText.StringResource(R.string.show_us_your_work)
@@ -503,7 +375,6 @@ class AccountViewModel(
             }
 
             4 -> UiText.StringResource(R.string.verify_your_identity_optional)
-
             else -> UiText.DynamicString("")
         }
     }
@@ -518,7 +389,6 @@ class AccountViewModel(
             }
 
             2 -> UiText.StringResource(R.string.use_to_personalize_experience_skip)
-
             3 -> when (screenState.value.accountUiState.userType) {
                 UserType.CUSTOMER -> UiText.StringResource(R.string.location_improves_accuracy_update_later)
                 UserType.CRAFTSMAN -> UiText.StringResource(R.string.add_photos_or_video_build_trust)
@@ -526,7 +396,6 @@ class AccountViewModel(
             }
 
             4 -> UiText.StringResource(R.string.upload_id_build_trust_get_jobs)
-
             else -> UiText.DynamicString("")
         }
     }
@@ -546,49 +415,37 @@ class AccountViewModel(
     private fun getGovernments() {
         tryToExecute(
             execute = { getLocationInfoUseCase.getGovernments() },
-            onSuccess = { governments ->
-                updateState(
-                    screenState.value.copy(
-                        accountUiState = screenState.value.accountUiState.copy(
-                            governments = governments
-                        )
-                    )
+            onSuccess = ::onGetGovernmentsSuccess,
+            onError = ::onError,
+        )
+    }
+
+    private fun onGetGovernmentsSuccess(governments: List<Governorate>) {
+        updateState(
+            screenState.value.copy(
+                accountUiState = screenState.value.accountUiState.copy(
+                    governments = governments
                 )
-            },
-            onError = { errorMessage ->
-                updateState(
-                    screenState.value.copy(
-                        errorMassage = errorMessage.message,
-                        isLoading = false
-                    )
-                )
-            },
+            )
         )
     }
 
     fun getCities(governorateId: Int) {
         tryToExecute(
-            execute = {
-                getLocationInfoUseCase.getCities(governorateId)
-            },
-            onSuccess = { cities ->
-                updateState(
-                    screenState.value.copy(
-                        accountUiState = screenState.value.accountUiState.copy(
-                            cities = cities,
-                            locationType = LocationBottomSheetContentType.CITY
-                        )
-                    )
+            execute = { getLocationInfoUseCase.getCities(governorateId) },
+            onSuccess = ::onGetCitiesSuccess,
+            onError = ::onError
+        )
+    }
+
+    private fun onGetCitiesSuccess(cities: List<City>) {
+        updateState(
+            screenState.value.copy(
+                accountUiState = screenState.value.accountUiState.copy(
+                    cities = cities,
+                    locationType = LocationBottomSheetContentType.CITY
                 )
-            },
-            onError = { errorMessage ->
-                updateState(
-                    screenState.value.copy(
-                        errorMassage = errorMessage.message,
-                        isLoading = false
-                    )
-                )
-            }
+            )
         )
     }
 
@@ -679,8 +536,6 @@ class AccountViewModel(
         )
     }
 
-
-    // Next Button actions
     override fun onUserTypeButtonClicked() {
         tryToExecute(
             execute = {
@@ -718,9 +573,7 @@ class AccountViewModel(
                     phone = screenState.value.accountUiState.phoneNumber,
                     step = AccountSetupStep.SERVICES
                 )
-                if (_currentScreen.intValue < stepsCount - 1) {
-                    _currentScreen.intValue++
-                }
+                incrementCurrentScreen()
             },
             onError = {
                 updateState(
@@ -740,15 +593,7 @@ class AccountViewModel(
     override fun onServiceButtonClicked() {
         tryToExecute(
             execute = {
-                updateState(
-                    screenState.value.copy(
-                        accountUiState = screenState.value.accountUiState.copy(
-                            accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
-                                serviceButtonState = AppButtonState.Loading
-                            )
-                        )
-                    )
-                )
+                changeAppButtonStateInService(AppButtonState.Loading)
                 val selectedServices =
                     screenState.value.accountUiState.serviceUiState.filter { it.isSelected }
                 val isCraftsman = screenState.value.accountUiState.userType == UserType.CRAFTSMAN
@@ -764,9 +609,7 @@ class AccountViewModel(
                     phone = screenState.value.accountUiState.phoneNumber,
                     step = AccountSetupStep.PERSONAL_INFO
                 )
-                if (_currentScreen.intValue < stepsCount - 1) {
-                    _currentScreen.intValue++
-                }
+                incrementCurrentScreen()
             },
             onError = {
                 updateState(
@@ -790,25 +633,9 @@ class AccountViewModel(
                 val profilePhotoUri =
                     screenState.value.accountUiState.customerProfilePhotoUri
                 if (fullName.isNotBlank()) {
-                    updateState(
-                        screenState.value.copy(
-                            accountUiState = screenState.value.accountUiState.copy(
-                                accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
-                                    profileButtonState = AppButtonState.Enable
-                                )
-                            )
-                        )
-                    )
+                    changeAppButtonStateInProfile(AppButtonState.Enable)
                 }
-                updateState(
-                    screenState.value.copy(
-                        accountUiState = screenState.value.accountUiState.copy(
-                            accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
-                                profileButtonState = AppButtonState.Loading
-                            )
-                        )
-                    )
-                )
+                changeAppButtonStateInProfile(AppButtonState.Loading)
                 setUpAccountUseCase.savePersonalInfo(
                     phone = screenState.value.accountUiState.phoneNumber,
                     fullName,
@@ -819,15 +646,7 @@ class AccountViewModel(
             onSuccess = {
                 if (screenState.value.accountUiState.userType == UserType.CRAFTSMAN) {
                     if (!screenState.value.accountUiState.workImagesUris.isNullOrEmpty()) {
-                        updateState(
-                            screenState.value.copy(
-                                accountUiState = screenState.value.accountUiState.copy(
-                                    accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
-                                        workShowCaseButtonState = AppButtonState.Enable
-                                    )
-                                )
-                            )
-                        )
+                        changeAppButtonStateInWorkShowCase(AppButtonState.Enable)
                     }
                     setUpAccountUseCase.updateUserProgress(
                         phone = screenState.value.accountUiState.phoneNumber,
@@ -839,9 +658,7 @@ class AccountViewModel(
                         step = AccountSetupStep.LOCATION
                     )
                 }
-                if (_currentScreen.intValue < stepsCount - 1) {
-                    _currentScreen.intValue++
-                }
+                incrementCurrentScreen()
             },
             onError = {
                 updateState(
@@ -886,12 +703,9 @@ class AccountViewModel(
                         .setPopUpTo(
                             Destinations.Account(accountSetupStep),
                             inclusive = true
-                        )
-                        .build()
+                        ).build()
                 )
-                if (_currentScreen.intValue < stepsCount - 1) {
-                    _currentScreen.intValue++
-                }
+                incrementCurrentScreen()
             },
             onError = {
                 updateState(
@@ -911,15 +725,7 @@ class AccountViewModel(
     override fun onShowWorkButtonClicked() {
         tryToExecute(
             execute = {
-                updateState(
-                    screenState.value.copy(
-                        accountUiState = screenState.value.accountUiState.copy(
-                            accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
-                                workShowCaseButtonState = AppButtonState.Loading
-                            )
-                        )
-                    )
-                )
+                changeAppButtonStateInWorkShowCase(AppButtonState.Loading)
                 setUpAccountUseCase.saveWorkShowcase(
                     phone = screenState.value.accountUiState.phoneNumber,
                     workMedia = screenState.value.accountUiState.workImagesUris,
@@ -931,9 +737,7 @@ class AccountViewModel(
                     phone = screenState.value.accountUiState.phoneNumber,
                     step = AccountSetupStep.UPLOAD_NATIONAL_ID
                 )
-                if (_currentScreen.intValue < stepsCount - 1) {
-                    _currentScreen.intValue++
-                }
+                incrementCurrentScreen()
             },
             onError = {
                 updateState(
@@ -953,30 +757,19 @@ class AccountViewModel(
     override fun onVerifyIdentityButtonClicked() {
         tryToExecute(
             execute = {
-                updateState(
-                    screenState.value.copy(
-                        accountUiState = screenState.value.accountUiState.copy(
-                            accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
-                                verifyIdentityButtonState = AppButtonState.Loading
-                            )
-                        )
-                    )
-                )
-
+                changeAppButtonStateInVerifyIdentity(AppButtonState.Loading)
                 setUpAccountUseCase.uploadNationalIdImages(
                     phone = screenState.value.accountUiState.phoneNumber,
                     screenState.value.accountUiState.frontOfNationalIdUri,
                     screenState.value.accountUiState.backOfNationalIdUri
                 )
-
                 navigate(
                     Destinations.CraftManGraph,
                     navOptions = NavOptions.Builder()
                         .setPopUpTo(
                             Destinations.Account(accountSetupStep),
                             inclusive = true
-                        )
-                        .build()
+                        ).build()
                 )
             },
             onSuccess = {
@@ -990,12 +783,9 @@ class AccountViewModel(
                         .setPopUpTo(
                             Destinations.Account(accountSetupStep),
                             inclusive = true
-                        )
-                        .build()
+                        ).build()
                 )
-                if (_currentScreen.intValue < stepsCount - 1) {
-                    _currentScreen.intValue++
-                }
+                incrementCurrentScreen()
             },
             onError = {
                 updateState(
@@ -1012,4 +802,66 @@ class AccountViewModel(
         )
     }
 
+    private fun incrementCurrentScreen() {
+        if (_currentScreen.intValue < stepsCount - 1) {
+            _currentScreen.intValue++
+        }
+    }
+
+    private fun onError(throwable: Throwable) {
+        updateState(
+            screenState.value.copy(
+                errorMassage = throwable.message,
+                isLoading = false
+            )
+        )
+    }
+
+    private fun changeAppButtonStateInService(appButtonState: AppButtonState) {
+        updateState(
+            screenState.value.copy(
+                accountUiState = screenState.value.accountUiState.copy(
+                    accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
+                        serviceButtonState = appButtonState
+                    )
+                )
+            )
+        )
+    }
+
+    private fun changeAppButtonStateInProfile(appButtonState: AppButtonState) {
+        updateState(
+            screenState.value.copy(
+                accountUiState = screenState.value.accountUiState.copy(
+                    accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
+                        profileButtonState = appButtonState
+                    )
+                )
+            )
+        )
+    }
+
+    private fun changeAppButtonStateInVerifyIdentity(appButtonState: AppButtonState) {
+        updateState(
+            screenState.value.copy(
+                accountUiState = screenState.value.accountUiState.copy(
+                    accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
+                        verifyIdentityButtonState = appButtonState
+                    )
+                )
+            )
+        )
+    }
+
+    private fun changeAppButtonStateInWorkShowCase(appButtonState: AppButtonState) {
+        updateState(
+            screenState.value.copy(
+                accountUiState = screenState.value.accountUiState.copy(
+                    accountButtonState = screenState.value.accountUiState.accountButtonState.copy(
+                        workShowCaseButtonState = appButtonState
+                    )
+                )
+            )
+        )
+    }
 }

--- a/app/src/main/java/com/paris_2/san3a/presentation/screen/account/components/AccountAppButton.kt
+++ b/app/src/main/java/com/paris_2/san3a/presentation/screen/account/components/AccountAppButton.kt
@@ -1,0 +1,37 @@
+package com.paris_2.san3a.presentation.screen.account.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.paris_2.san3a.presentation.shared.components.AppButton
+import com.paris_2.san3a.presentation.shared.components.AppButtonSize
+import com.paris_2.san3a.presentation.shared.components.AppButtonState
+import com.paris_2.san3a.presentation.shared.components.AppButtonType
+import com.paris_2.san3a.presentation.shared.components.LoadingScreen
+import com.paris_2.san3a.presentation.shared.designSystem.theme.Theme
+
+@Composable
+fun AccountAppButton(
+    onClickButton: () -> Unit,
+    textButton: String,
+    state: AppButtonState,
+    modifier: Modifier = Modifier
+) {
+    AppButton(
+        onClick = onClickButton,
+        type = AppButtonType.Primary,
+        text = textButton,
+        state = state,
+        modifier = modifier.fillMaxWidth(),
+        size = AppButtonSize.Large,
+        loadingIcon = {
+            LoadingScreen(
+                modifier = modifier.size(25.dp),
+                background = Theme.colors.button.primary
+            )
+        }
+
+    )
+}

--- a/app/src/main/java/com/paris_2/san3a/presentation/screen/account/components/AccountAppButton.kt
+++ b/app/src/main/java/com/paris_2/san3a/presentation/screen/account/components/AccountAppButton.kt
@@ -28,7 +28,7 @@ fun AccountAppButton(
         size = AppButtonSize.Large,
         loadingIcon = {
             LoadingScreen(
-                modifier = modifier.size(25.dp),
+                modifier = Modifier.size(25.dp),
                 background = Theme.colors.button.primary
             )
         }


### PR DESCRIPTION
This pull request refactors the account screen's button usage by introducing a new reusable `AccountAppButton` component and replacing multiple instances of the generic `AppButton` with it. This improves code maintainability and consistency across the account-related screens. Additionally, minor layout and import cleanups are included.

### Component Refactoring

* Added a new reusable `AccountAppButton` composable to encapsulate button logic and styling for the account screens (`AccountAppButton.kt`).
* Replaced all instances of `AppButton` in `AccountScreen.kt` with the new `AccountAppButton`, simplifying button usage and reducing repeated code. 

### Code Cleanup

* Removed unused imports of generic button components and related types from `AccountScreen.kt`, as these are now handled by `AccountAppButton`.
* Updated layout padding in `AccountScreenContent` for more concise and readable code.
* Minor formatting improvements for modifiers and composable parameters to enhance readability. 