### PR TITLE
Fix: Adjust AppButton vertical padding for non-large sizes

### DIFF
--- a/app/src/main/java/com/paris_2/san3a/presentation/shared/components/AppButton.kt
+++ b/app/src/main/java/com/paris_2/san3a/presentation/shared/components/AppButton.kt
@@ -221,7 +221,7 @@ private fun getAppContentPadding(
         return when (type) {
             AppButtonType.Primary, AppButtonType.Secondary -> PaddingValues(
                 horizontal = horizontalPadding.value,
-                vertical = animateDpAsState(if (isLarge) 15.dp else 13.dp).value
+                vertical = animateDpAsState(if (isLarge) 15.dp else 10.dp).value
             )
 
             AppButtonType.Tertiary -> PaddingValues(


### PR DESCRIPTION
Fix: Adjust AppButton vertical padding for non-large sizes

The vertical padding for non-large AppButtons of type Primary and Secondary has been changed from 13.dp to 10.dp.