### PR TITLE
bug-fix/last-time-fixing-ui-issues

### DIFF
--- a/app/src/main/java/com/paris_2/san3a/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/paris_2/san3a/data/repository/UserRepositoryImpl.kt
@@ -196,21 +196,25 @@ class UserRepositoryImpl(
     override suspend fun uploadNationalIdImages(phone: String, frontUri: Uri?, backUri: Uri?) =
         coroutineScope {
             safeNetworkCall(FailException("Failed to upload national ID images")) {
-                val (frontUrl, backUrl) = listOfNotNull(
-                    frontUri?.let { uri ->
-                        async {
-                            val path = "$NATIONAL_ID_PATH/$phone/$FRONT_IMAGE_NAME"
-                            storageRemoteDataSource.saveImages(listOf(ImageDto(path, uri))).firstOrNull()
+                if (frontUri!=null || backUri!=null) {
+                    val (frontUrl, backUrl) = listOfNotNull(
+                        frontUri?.let { uri ->
+                            async {
+                                val path = "$NATIONAL_ID_PATH/$phone/$FRONT_IMAGE_NAME"
+                                storageRemoteDataSource.saveImages(listOf(ImageDto(path, uri)))
+                                    .firstOrNull()
+                            }
+                        },
+                        backUri?.let { uri ->
+                            async {
+                                val path = "$NATIONAL_ID_PATH/$phone/$BACK_IMAGE_NAME"
+                                storageRemoteDataSource.saveImages(listOf(ImageDto(path, uri)))
+                                    .firstOrNull()
+                            }
                         }
-                    },
-                    backUri?.let { uri ->
-                        async {
-                            val path = "$NATIONAL_ID_PATH/$phone/$BACK_IMAGE_NAME"
-                            storageRemoteDataSource.saveImages(listOf(ImageDto(path, uri))).firstOrNull()
-                        }
-                    }
-                ).awaitAll()
-                userRemoteDataSource.updateNationalIdImages(phone, frontUrl, backUrl)
+                    ).awaitAll()
+                    userRemoteDataSource.updateNationalIdImages(phone, frontUrl, backUrl)
+                }
             }
         }
 

--- a/app/src/main/java/com/paris_2/san3a/presentation/screen/account/AccountScreen.kt
+++ b/app/src/main/java/com/paris_2/san3a/presentation/screen/account/AccountScreen.kt
@@ -8,10 +8,14 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -97,7 +101,9 @@ fun AccountScreenContent(
             .background(Theme.colors.background.screen)
             .statusBarsPadding()
             .navigationBarsPadding()
+            .imePadding()
             .padding(horizontal = 16.dp, vertical = 16.dp)
+            .verticalScroll(rememberScrollState())
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -169,7 +175,7 @@ fun AccountScreenContent(
             3 -> when (uiState.accountUiState.userType) {
                 UserType.CUSTOMER -> {
                     LocationContent(
-                        modifier = Modifier.padding(vertical = 32.dp),
+                        modifier = Modifier.padding(vertical = 32.dp).fillMaxWidth().height(200.dp),
                         onGetLocationClicked = interactionListener::onGovernmentBottomSheetVisibilityToggled,
                         isGovernmentSheetShowed = uiState.accountUiState.isGovernmentBottomSheetShowed,
                         onGovernmentDismissRequest = interactionListener::onGovernmentBottomSheetDismissed,

--- a/app/src/main/java/com/paris_2/san3a/presentation/screen/account/AccountScreen.kt
+++ b/app/src/main/java/com/paris_2/san3a/presentation/screen/account/AccountScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size

--- a/app/src/main/java/com/paris_2/san3a/presentation/screen/account/components/AccountCameraComponent.kt
+++ b/app/src/main/java/com/paris_2/san3a/presentation/screen/account/components/AccountCameraComponent.kt
@@ -51,7 +51,7 @@ fun AddWorkPhotosComponent(
     onAddPhotoClick: () -> Unit,
     onDeletePhotoClick: (url: Uri) -> Unit = {},
 ) {
-    if (images == null) {
+    if (images == null || images.isEmpty()) {
         Box(
             modifier = modifier
                 .height(96.dp)

--- a/app/src/main/java/com/paris_2/san3a/presentation/screen/account/components/AccountSelectionCard.kt
+++ b/app/src/main/java/com/paris_2/san3a/presentation/screen/account/components/AccountSelectionCard.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import com.paris_2.san3a.presentation.utill.myClickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
@@ -68,7 +69,7 @@ fun AccountSelectionCard(
         Image(
             painter = userImage,
             contentDescription = stringResource(R.string.user_image),
-            modifier = Modifier.padding(12.dp)
+            modifier = Modifier.padding(12.dp).height(132.dp)
         )
         Text(
             text = title,

--- a/app/src/main/java/com/paris_2/san3a/presentation/screen/account/components/AccountTypeStepContent.kt
+++ b/app/src/main/java/com/paris_2/san3a/presentation/screen/account/components/AccountTypeStepContent.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.unit.dp
 import com.paris_2.san3a.R
 import com.paris_2.san3a.presentation.screen.account.UserType
 import com.paris_2.san3a.presentation.shared.designSystem.theme.San3aTheme
+import com.paris_2.san3a.presentation.shared.utils.PreviewMultiDevices
 
 @Composable
 fun AccountTypeContent(
@@ -40,7 +41,7 @@ fun AccountTypeContent(
     }
 }
 
-@Preview
+@PreviewMultiDevices
 @Composable
 private fun StepOneContentPreview() {
     San3aTheme {

--- a/app/src/main/java/com/paris_2/san3a/presentation/screen/account/components/AccountTypeStepContent.kt
+++ b/app/src/main/java/com/paris_2/san3a/presentation/screen/account/components/AccountTypeStepContent.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.paris_2.san3a.R
 import com.paris_2.san3a.presentation.screen.account.UserType


### PR DESCRIPTION
Adjust AccountScreen layout and LocationContent sizing

- Enable vertical scrolling and IME padding in `AccountScreen`.
- Set `fillMaxWidth` and `height(200.dp)` for `LocationContent` when user type is CUSTOMER.
- Remove unused preview from `AccountTypeStepContent.kt`.